### PR TITLE
fix: override circle getBounds before map is bound

### DIFF
--- a/src/layers/Buffer.js
+++ b/src/layers/Buffer.js
@@ -1,6 +1,7 @@
-import L from 'leaflet';
-import turfBuffer from '@turf/buffer';
-import { GeoJson } from './GeoJson';
+import L from 'leaflet'
+import turfBuffer from '@turf/buffer'
+import { GeoJson } from './GeoJson'
+import { Circle } from './Circle'
 
 export const Buffer = GeoJson.extend({
     options: {
@@ -17,46 +18,48 @@ export const Buffer = GeoJson.extend({
 
     initialize(options = {}) {
         // Replace polygons with buffered geometries
-        options.data = options.data.map(feature => 
-            feature.geometry.type !== 'Point' ? {
-                ...feature,
-                geometry: turfBuffer(feature, options.buffer / 1000).geometry, // km
-            } : feature
-        );
+        options.data = options.data.map(feature =>
+            feature.geometry.type !== 'Point'
+                ? {
+                      ...feature,
+                      geometry: turfBuffer(feature, options.buffer / 1000)
+                          .geometry, // km
+                  }
+                : feature
+        )
 
-        GeoJson.prototype.initialize.call(this, options);
+        GeoJson.prototype.initialize.call(this, options)
     },
 
     // Set color from feature
     addLayer(layer) {
-        const { feature } = layer;
-        const { color } = feature.properties;
+        const { feature } = layer
+        const { color } = feature.properties
 
         if (color && layer.setStyle) {
-            layer.setStyle({ color });
+            layer.setStyle({ color })
         }
 
-        GeoJson.prototype.addLayer.call(this, layer);
+        GeoJson.prototype.addLayer.call(this, layer)
     },
 
     pointToLayer(geojson, latlng) {
-        this.options.style.pane = this.options.pane;
-
         // Draw points as circles using buffer as radius
-        return L.circle(latlng, {
+        return new Circle(latlng, {
             ...this.options.style,
+            pane: this.options.pane,
             radius: this.options.buffer,
-        });
+        })
     },
 
     setOpacity(opacity) {
         this.setStyle({
             opacity,
             fillOpacity: opacity * this.options.opacityFactor,
-        });
+        })
     },
-});
+})
 
 export default function buffer(options) {
-    return new Buffer(options);
+    return new Buffer(options)
 }

--- a/src/layers/Circle.js
+++ b/src/layers/Circle.js
@@ -1,0 +1,37 @@
+import L from 'leaflet'
+import { toLngLat } from '../utils/geometry'
+
+// Creates a circle marker from a GeoJSON feature
+// Used for GeoJSON, client and server cluster
+export const Circle = L.Circle.extend({
+    options: {
+        weight: 0.5,
+        radius: 6,
+    },
+
+    initialize(latlng, options) {
+        options.fillOpacity = options.opacity
+
+        this._lnglat = toLngLat(latlng)
+
+        L.Circle.prototype.initialize.call(this, latlng, options)
+    },
+
+    getBounds() {
+        if (!this._map) {
+            return this._lnglat
+        }
+        L.Circle.prototype.getBounds.call(this)
+    },
+
+    setOpacity(opacity) {
+        this.setStyle({
+            opacity,
+            fillOpacity: opacity,
+        })
+    },
+})
+
+export default function circle(feature, options) {
+    return new Circle(feature, options)
+}


### PR DESCRIPTION
Fix for DHIS2-6667.  This was a BEAST to track down and I still don't know exactly why it happened in the plugin but not in the main app - something to do with the timing of the `fitBounds` calls.

Basically, there's a bug in `L.Circle` which crashes if `getBounds` is called before the circle is added to the map (since the circle needs to be projected to figure out the actual bounds).  We sometimes do that, and we use Circle when constructing geographic-unit (meter rather than pixel) buffer layers.  To get around this I overloaded the Circle class and added a fallback for `getBounds` which will return just the center of the circle if `this._map` isn't assigned yet.  This seems to be innocuous (if expensive) since we're fitting bounds both before and after the layers are added to the map.

There may be a nicer way to do this, but this is the first solution I came up with that actually addressed the problem (and there were about 48 hours of false leads along the way)