### PR TITLE
feat: new getZoom method

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -159,6 +159,11 @@ export class Map extends L.Evented {
         }
     }
 
+    // Returns the map zoom level
+    getZoom() {
+        return this._map.getZoom()
+    }
+
     // Returns true if the layer type is supported
     hasLayerSupport(type) {
         return !!this.options.layerTypes[type]


### PR DESCRIPTION
Added a new getZoom method that we can be used to get the current zoom level, or to check if the map is already zoomed. 