### PR TITLE
Create unique pane for each EE layer

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -15,7 +15,7 @@ export const EarthEngine = L.LayerGroup.extend({
     },
 
     initialize(options) {
-        L.setOptions(this, options)
+        L.setOptions(this, { ...options, pane: options.id })
         this._layers = {}
         this._legend = options.legend || this.createLegend()
     },

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -19,7 +19,7 @@ export const ServerCluster = L.GridLayer.extend({
     },
 
     initialize(opts) {
-        const options = L.setOptions(this, opts)
+        const options = L.setOptions(this, { ...opts, pane: opts.id })
         this._clusters = L.featureGroup() // Clusters shown on map
         this._tileClusters = {} // Cluster cache
         this._scale = scaleLog()


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7345

Before this fix, each EE layer was be added to the same layer pane, and then they could not be toggled individually or reordered. This fix uses the layer id when naming the pane, as we do with the other layer types. 

Will update the Maps app when this PR is approved and merged. 