### PR TITLE
Google Maps API upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/gis-api",
-    "version": "33.0.7",
+    "version": "33.0.8",
     "description": "Maps API for DHIS2 based on Leaflet",
     "main": "lib/main/index.js",
     "scripts": {

--- a/src/layers/GoogleLayer.js
+++ b/src/layers/GoogleLayer.js
@@ -9,7 +9,7 @@ export const GoogleLayer = L.GridLayer.GoogleMutant.extend({
 
     options: {
         style: 'ROADMAP', // ROADMAP, SATELLITE, HYBRID, TERRAIN
-        version: '3.35', // Google Maps API version
+        version: '3.38', // Google Maps API version
     },
 
     initialize(opts = {}) {


### PR DESCRIPTION
Upgrade to the latest version (3.38) of Google Maps API. Version 3.35 is retired. 