### PR TITLE
feat: layer types as static method

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -74,16 +74,20 @@ export class Map extends L.Evented {
     addLayer(layer) {
         let newLayer = layer
 
-        if (layer.type && layerTypes[layer.type]) {
+        if (layer.type) {
             newLayer = this.createLayer(layer)
         }
 
-        newLayer.createPane(this._map)
+        if (newLayer instanceof L.Layer) {
+            newLayer.createPane(this._map)
 
-        this._map.addLayer(newLayer)
-        this._layers.push(newLayer)
+            this._map.addLayer(newLayer)
+            this._layers.push(newLayer)
 
-        return newLayer
+            return newLayer
+        } 
+
+        return null;
     }
 
     removeLayer(layer) {
@@ -103,7 +107,13 @@ export class Map extends L.Evented {
     }
 
     createLayer(layer) {
-        return layerTypes[layer.type](layer)
+        const layerFactory = layerTypes[layer.type]
+
+        if (layerFactory) {
+            return layerFactory(layer)
+        }
+
+        return null
     }
 
     addControl(control) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -18,7 +18,6 @@ export class Map extends L.Evented {
         controls: [],
         worldCopyJump: true,
         maxZoom: 18,
-        layerTypes,
         controlTypes: {
             fitBounds,
             search,
@@ -73,7 +72,6 @@ export class Map extends L.Evented {
 
     // Accept layer as config object
     addLayer(layer) {
-        const { layerTypes } = this.options
         let newLayer = layer
 
         if (layer.type && layerTypes[layer.type]) {
@@ -105,7 +103,7 @@ export class Map extends L.Evented {
     }
 
     createLayer(layer) {
-        return this.options.layerTypes[layer.type](layer)
+        return layerTypes[layer.type](layer)
     }
 
     addControl(control) {
@@ -169,8 +167,8 @@ export class Map extends L.Evented {
     }
 
     // Returns true if the layer type is supported
-    hasLayerSupport(type) {
-        return !!this.options.layerTypes[type]
+    static hasLayerSupport(type) {
+        return !!layerTypes[type]
     }
 
     openPopup(content, lnglat, onClose) {


### PR DESCRIPTION
We need a way to check if the API support different layer types. The GIS API supports Google layers, while Maps GL don't. This PR allows us to check if a layer type is supported without creating a map instance (static method). 