### PR TITLE
Spiderify cluster fix

### DIFF
--- a/src/layers/ClusterMarker.js
+++ b/src/layers/ClusterMarker.js
@@ -68,6 +68,7 @@ export const ClusterMarker = L.Marker.extend({
                                 type: 'Point',
                                 coordinates: [newPos.lng, newPos.lat],
                             },
+                            properties: {}
                         },
                         this.options
                     )
@@ -105,7 +106,20 @@ export const ClusterMarker = L.Marker.extend({
     },
 
     onSpiderMarkerClick(evt) {
-        evt.layer.showPopup()
+        if (this.options.onClick) {
+            const { type, latlng, layer } = evt
+            const coordinates = [latlng.lng, latlng.lat]
+            
+            // Show coordinates from the original feature, not the spider
+            const feature = {
+                ...layer.feature,
+                geometry: {
+                    ...this._feature.geometry
+                },
+            }
+
+            this.options.onClick({ type, coordinates, feature })
+        }
     },
 
     onRemove(map) {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7753

This PR fixes issues when server cluster events have the same position. When a cluster is clicked, a "spider" will be shown at max zoom. Each event can be clicked, and the associated popup will be shown. The same coordinate will shown for all events in the spider.  

![Skjermbilde 2019-10-22 kl  15 49 25](https://user-images.githubusercontent.com/548708/67292635-91a87280-f4e3-11e9-8de0-21d44db355d7.png)
