### PR TITLE
refactor: unify maps interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@turf/buffer": "^5.1.5",
         "d3-color": "^1.2.3",
         "d3-scale": "^2.2.2",
-        "leaflet": "^1.5.1",
+        "leaflet": "^1.6.0",
         "leaflet-control-geocoder": "^1.6.0",
         "leaflet-measure": "3.1.0",
         "leaflet.gridlayer.googlemutant": "^0.8.0",

--- a/src/Map.js
+++ b/src/Map.js
@@ -17,7 +17,7 @@ export class Map extends L.Evented {
         zoomControl: false,
         controls: [],
         worldCopyJump: true,
-        maxZoom: 18, 
+        maxZoom: 18,
         controlTypes: {
             fitBounds,
             search,

--- a/src/Map.js
+++ b/src/Map.js
@@ -17,7 +17,7 @@ export class Map extends L.Evented {
         zoomControl: false,
         controls: [],
         worldCopyJump: true,
-        maxZoom: 18,
+        maxZoom: 18, 
         controlTypes: {
             fitBounds,
             search,

--- a/src/layerTypes.js
+++ b/src/layerTypes.js
@@ -21,6 +21,7 @@ export default {
     markers, // Facility layer
     choropleth, // Thematic layer
     clientCluster, // Event layer
+    donutCluster: clientCluster, // Event layer, not supported in GIS API, fallback to clientCluster
     serverCluster, // Event layer
     earthEngine, // Google Earth Engine layer
     group, // A collection of layers

--- a/src/layers/ClusterMarker.js
+++ b/src/layers/ClusterMarker.js
@@ -10,7 +10,7 @@ export const ClusterMarker = L.Marker.extend({
 
         options.icon = clusterIcon({
             size: feature.properties.size,
-            count: feature.properties.count,
+            count: feature.properties.point_count,
             color: options.fillColor,
         })
 
@@ -32,8 +32,8 @@ export const ClusterMarker = L.Marker.extend({
             const map = this._map
             const latlng = this.getLatLng()
             const center = map.latLngToLayerPoint(latlng)
-            const ids = (this._feature.id || '').split(',')
-            const count = feature.properties.count
+            const ids = (this._feature.properties.id || '').split(',')
+            const count = feature.properties.point_count
             const legOptions = { weight: 1.5, color: '#222', opacity: 0.5 }
             const _2PI = Math.PI * 2
             const circumference = 13 * (2 + count)
@@ -62,13 +62,14 @@ export const ClusterMarker = L.Marker.extend({
                 this._spiderMarkers.addLayer(
                     circleMarker(
                         {
-                            id,
                             type: 'Feature',
                             geometry: {
                                 type: 'Point',
                                 coordinates: [newPos.lng, newPos.lat],
                             },
-                            properties: {}
+                            properties: {
+                                id
+                            }
                         },
                         this.options
                     )

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -22,7 +22,7 @@ export const ServerCluster = L.GridLayer.extend({
         const options = L.setOptions(this, { 
             ...opts, 
             pane: opts.id, 
-            bounds: toLatLngBounds(opts.bounds) 
+            ...(opts.bounds && {bounds: toLatLngBounds(opts.bounds)})
         })
 
         this._clusters = L.featureGroup() // Clusters shown on map

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -4,7 +4,7 @@ import clusterMarker from './ClusterMarker'
 import circleMarker from './CircleMarker'
 import polygon from './Polygon'
 import layerMixin from './layerMixin'
-import { toLngLatBounds } from '../utils/geometry'
+import { toLatLngBounds, toLngLatBounds } from '../utils/geometry'
 
 export const ServerCluster = L.GridLayer.extend({
     ...layerMixin,
@@ -19,7 +19,12 @@ export const ServerCluster = L.GridLayer.extend({
     },
 
     initialize(opts) {
-        const options = L.setOptions(this, { ...opts, pane: opts.id })
+        const options = L.setOptions(this, { 
+            ...opts, 
+            pane: opts.id, 
+            bounds: toLatLngBounds(opts.bounds) 
+        })
+
         this._clusters = L.featureGroup() // Clusters shown on map
         this._tileClusters = {} // Cluster cache
         this._scale = scaleLog()
@@ -28,7 +33,6 @@ export const ServerCluster = L.GridLayer.extend({
             .range(options.range)
             .clamp(true)
         this._clusters.on('click', this.onClusterClick, this)
-        this._bounds = options.bounds
     },
 
     onAdd(map) {
@@ -102,7 +106,7 @@ export const ServerCluster = L.GridLayer.extend({
             // Is cluster
             if (map.getZoom() !== map.getMaxZoom()) {
                 // Zoom to cluster bounds
-                map.fitBounds(marker.getBounds())
+                map.fitBounds(toLatLngBounds(marker.getBounds()))
             } else {
                 // Spiderify on last zoom
                 if (this._spider) {
@@ -141,13 +145,13 @@ export const ServerCluster = L.GridLayer.extend({
         const { options } = this
         let marker
 
-        if (feature.properties.count === 1) {
+        if (feature.properties.point_count === 1) {
             marker =
                 feature.geometry.type === 'Point'
                     ? circleMarker(feature, options)
                     : polygon(feature, options)
         } else {
-            feature.properties.size = this._scale(feature.properties.count)
+            feature.properties.size = this._scale(feature.properties.point_count)
             marker = clusterMarker(feature, this.options)
         }
 
@@ -165,8 +169,8 @@ export const ServerCluster = L.GridLayer.extend({
 
     // Returns bounds for all clusters
     getBounds() {
-        const bounds = this._bounds
-            ? L.latLngBounds(this._bounds)
+        const bounds = this.options.bounds
+            ? L.latLngBounds(this.options.bounds)
             : this._clusters.getBounds()
 
         if (bounds.isValid()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6637,10 +6637,10 @@ leaflet.markercluster@^1.4.1:
   resolved "https://registry.yarnpkg.com/leaflet.markercluster/-/leaflet.markercluster-1.4.1.tgz#b53f2c4f2ca7306ddab1dbb6f1861d5e8aa6c5e5"
   integrity sha512-ZSEpE/EFApR0bJ1w/dUGwTSUvWlpalKqIzkaYdYB7jaftQA/Y2Jav+eT4CMtEYFj+ZK4mswP13Q2acnPBnhGOw==
 
-leaflet@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.5.1.tgz#9afb9d963d66c870066b1342e7a06f92840f46bf"
-  integrity sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w==
+leaflet@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.6.0.tgz#aecbb044b949ec29469eeb31c77a88e2f448f308"
+  integrity sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ==
 
 left-pad@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This PR includes some smaller changes to unfify the interface between the old GIS API and upcoming MAPS GL.

- Maps GL support "donut clusters", which will not be backported to GIS API. We accept the new layer type, with a fallback to clientCluster which will show clusters without the pie chart. 
- "count" is renamed to "point_count" to adhere to the Mapbox GL cluster format. 
- Mapbox only support number feature ids. As we use the string-based uid format, we read the id from feature properties. 
- We now supply coordinates in the GeoJSON-format [lng,lat], so we need to do some coordinates conversions for Leaflet that uses [lat,lng]  

The PR also include the latest Leaflet version 1.6.0. 
