### PR TITLE
feat: export supported layer types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Map from "./Map";
-import types  from './layers/layerTypes'
+import types from './layerTypes';
 import "../scss/gis-api.scss";
 
 // When this file was included in EarthEngine.js it caused error when running tests

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
 import Map from "./Map";
+import types  from './layers/layerTypes'
 import "../scss/gis-api.scss";
 
 // When this file was included in EarthEngine.js it caused error when running tests
 // This file is never loaded by test scripts
 import "script-loader!@google/earthengine/build/ee_api_js";
+
+// Export supported layer types as an array
+export const layerTypes = Object.keys(types);
 
 export default Map;


### PR DESCRIPTION
Small PR that exports the layer types supported by this API. It can be used to filter a list of map layers to only show supported types, e.g. GIS API supports "googleLayer" and Maps GL supports "bingLayer". 